### PR TITLE
add link to github repo

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,19 @@ WriteMakefile(
   VERSION_FROM => 'dirdim.pm',
   EXE_FILES => [ 'dirdim' ],
   AUTHOR => 'Toshiyuki SHIMONO (bin4tsv at gmail.com)',
-  LICENSE => 'perl_5'
+  LICENSE => 'perl_5',
+  META_MERGE => {
+      'meta-spec' => { version => 2 },
+       resources => {
+           repository => {
+               type => 'git',
+               url  => 'https://github.com/tulamili/App-dirdim.git',
+               web  => 'https://github.com/tulamili/App-dirdim',
+           },
+           bugtracker => {
+               web => 'https://github.com/tulamili/App-dirdim/issues'
+           },
+       },
+  },
 );
 


### PR DESCRIPTION
Upon the next release this will include the link in the META files that come with the distribution that will allow MetaCPAN to link to the repo. That will make it easier for a potential contributor to find the source code.